### PR TITLE
Print exit status on http errors

### DIFF
--- a/cronsul
+++ b/cronsul
@@ -16,8 +16,11 @@ grab_lock_or_die() {
     local task_id="$1"
     local schedule_date="$2"
     local period="$3"
-    ret="$(curl -s -X PUT -d "${HOSTNAME}" "${CONSUL_ADDR}/v1/kv/cronsul/${task_id}/${period}/${schedule_date}?cas=0")"
+    ret="$(curl -sS -X PUT -d "${HOSTNAME}" "${CONSUL_ADDR}/v1/kv/cronsul/${task_id}/${period}/${schedule_date}?cas=0")"
     if [[ "$ret" != "true" ]]; then
+        if [[ "$ret" != "false" ]]; then
+             echo $ret
+        fi
         exit
     fi
 }


### PR DESCRIPTION
When error codes are returned from consul/http failed to connect codes print them out so we know there's an underlying problem.
