### PR TITLE
Fix positional arg count for default period

### DIFF
--- a/cronsul
+++ b/cronsul
@@ -26,7 +26,7 @@ grab_lock_or_die() {
 }
 
 # Parse command line arguments.
-if [[ "$#" -lt 3 ]]; then
+if [[ "$#" -lt 2 ]]; then
     usage
 fi
 task_id="$1"


### PR DESCRIPTION
The number of positional arguments was incorrect, so you were unable to run cronsul without specifying the period.
