### PR TITLE
exit with failed code on lock

### DIFF
--- a/cronsul
+++ b/cronsul
@@ -21,7 +21,7 @@ grab_lock_or_die() {
         if [[ "$ret" != "false" ]]; then
              echo $ret
         fi
-        exit
+        exit 1
     fi
 }
 


### PR DESCRIPTION
We rely on the exit code from cronsul to determinate logic after the fact.  Changing the exit code when a lock already exists will help us to determine resultant logic.
